### PR TITLE
Build script improvements

### DIFF
--- a/@build_baserom.bat
+++ b/@build_baserom.bat
@@ -21,46 +21,55 @@ set /p Action=Enter the number of your choice:
 :: Apply asar patches
 if "%Action%"=="1" (
     echo Applying patches...
-    cd .\common\
+    pushd .\common\
     for /f "tokens=*" %%a in (list_asar.txt) do (.\asar.exe -v asar\%%a %ROMFILE%)
     echo Done.
 )
 :: Insert custom blocks with GPS
 if "%Action%"=="2" (
     echo Inserting custom blocks...
-    cd .\common\
+    pushd .\common\
     .\gps.exe -l "list_gps.txt" %ROMFILE%
     echo Done.
 )
 :: Insert Custom Sprites with PIXI
 if "%Action%"=="3" (
     echo Inserting custom sprites...
-    cd .\common\
+    pushd .\common\
     .\pixi.exe -l "common\list_pixi.txt" %ROMFILE%
     echo Done.
 )
 :: Insert custom music with AddmusicK
 if "%Action%"=="4" (
     echo Inserting custom Music...
-    cd .\AddmusicK_1.0.8\
+    pushd .\AddmusicK_1.0.8\
     .\AddmusicK.exe %ROMFILE%
     echo Done.
 )
 :: Insert custom uberASM
 if "%Action%"=="5" (
     echo Inserting UberASM...
-    cd .\common\
+    pushd .\common\
     .\UberASMTool.exe "list_uberasm.txt"
     echo Done.
 )
 :: Create bps Patch with Flips
 if "%Action%"=="6" (
     echo Creating BPS patch...
-    cd .\common\
-    .\flips.exe --create --bps ..\sysLMRestore\smwOrig.smc %ROMFILE% ..\RHR4.bps
+    pushd .\common\
+	if not exist ..\sysLMRestore\smwOrig.smc (
+		echo Could not find an unmodified SMW file.
+		set /p SMW_ORIG=Enter the path to an original, unmodified SMW smc: 
+	) else (
+		set SMW_ORIG=..\sysLMRestore\smwOrig.smc
+	)
+    .\flips.exe --create --bps %SMW_ORIG% %ROMFILE% ..\RHR4.bps
     echo Done.
 )
+
+popd
+
 if "%Action%"=="0" (
-    exit
+    exit /b
 )
 if '%Action%'=='' echo %choice%" is not valid please try again.


### PR DESCRIPTION
1. Don't exit the shell when exiting the script
2. If the original SMW rom isn't found, prompt for one
3. pushd and popd directory changes to not pollute the shell's CWD