### PR TITLE
Move SwitchPalette to the end of the file in p-switch spawning blocks

### DIFF
--- a/tools/gps/blocks/question_blocks/3E_blue_pswitch.asm
+++ b/tools/gps/blocks/question_blocks/3E_blue_pswitch.asm
@@ -11,8 +11,6 @@ print "Question block that always spawns a Blue P-Switch/POW."
 !Placement = %move_spawn_above_block()
 		; Use %move_spawn_above_block() if the sprite should appear above the block, otherwise %move_spawn_into_block()
 
-SwitchPalette: db $06,$02
-
 JMP MarioBelow : JMP Return : JMP Return
 JMP SpriteV : JMP SpriteH
 JMP Cape : JMP Return
@@ -86,3 +84,5 @@ SpawnItem:
 	PLY
 	PLX
 	RTL
+
+SwitchPalette: db $06,$02

--- a/tools/gps/blocks/question_blocks/3E_silver_pswitch.asm
+++ b/tools/gps/blocks/question_blocks/3E_silver_pswitch.asm
@@ -11,8 +11,6 @@ print "Question block that always spawns a Silver P-Switch/POW."
 !Placement = %move_spawn_above_block()
 		; Use %move_spawn_above_block() if the sprite should appear above the block, otherwise %move_spawn_into_block()
 
-SwitchPalette: db $06,$02
-
 JMP MarioBelow : JMP Return : JMP Return
 JMP SpriteV : JMP SpriteH
 JMP Cape : JMP Return
@@ -86,3 +84,5 @@ SpawnItem:
 	PLY
 	PLX
 	RTL
+
+SwitchPalette: db $06,$02


### PR DESCRIPTION
This fixes a crash when interacting with the sides of these blocks.